### PR TITLE
Fix: Assurer la compatibilité avec C# 7.3

### DIFF
--- a/FredChessGame/Model/Plateau.cs
+++ b/FredChessGame/Model/Plateau.cs
@@ -12,8 +12,7 @@ namespace FredChessGame
     {
       Console.WriteLine("Création d'un nouveau plateau...");
       InitialiserPieces();
-      // Les blancs commencent
-      JoueurActuel = PieceColor.Blanc; 
+      JoueurActuel = PieceColor.Blanc; // Les blancs commencent
       Console.WriteLine("Plateau initialisé avec succès.");
     }
 

--- a/FredChessGame/ViewModel/ChessViewModel.cs
+++ b/FredChessGame/ViewModel/ChessViewModel.cs
@@ -17,8 +17,9 @@ public class ChessViewModel: INotifyPropertyChanged
 
   private void OnCaseCliquee(object param)
   {
-    if (param is not Tuple<int, int> position)
-      return;
+    var position = param as Tuple<int, int>;
+    if (position == null)
+        return;
 
     int row = position.Item1;
     int col = position.Item2;


### PR DESCRIPTION
Le code a été modifié pour remplacer une construction syntaxique de C# 9.0 (`is not`) qui provoquait une erreur de compilation dans les environnements utilisant une version plus ancienne de C#. La logique a été réécrite en utilisant l'opérateur `as` avec une vérification de nullité pour garantir la compatibilité avec C# 7.3.