### PR TITLE
Fix: Corriger l'instanciation de RelayCommand

### DIFF
--- a/FredChessGame/ViewModel/ChessViewModel.cs
+++ b/FredChessGame/ViewModel/ChessViewModel.cs
@@ -12,7 +12,7 @@ public class ChessViewModel: INotifyPropertyChanged
 
   public ChessViewModel()
   {
-    CaseCliqueeCommand = new RelayCommand(param => OnCaseCliquee(param));
+    CaseCliqueeCommand = new RelayCommand<object>(OnCaseCliquee);
   }
 
   private void OnCaseCliquee(object param)


### PR DESCRIPTION
Le constructeur de `RelayCommand` a été corrigé pour utiliser la version générique `RelayCommand<object>`. Cela résout une erreur de compilation où un délégué avec un paramètre était passé à un constructeur qui attendait un délégué sans paramètre.